### PR TITLE
fix small bug in initialisation of Psquare

### DIFF
--- a/psquare/psquare.py
+++ b/psquare/psquare.py
@@ -79,8 +79,7 @@ class PSquare:
             if len(self.marker_heights) == 5:
                 self.initiated = True
                 self.marker_heights = np.sort(self.marker_heights)
-            else:
-                return
+            return
 
         i = self.find_cell(new_observation)
         if i == -1:


### PR DESCRIPTION
I think this was a small bug in the initialisation of psquare. The algorithm should not update positions and heights when it inititalises. 

Example bad case:
```
values = [-0.93440463,  1.762478  , -0.13665276, -0.50844987,  0.69265]
psquare = PSquare(50)
for val in values:
    psquare.update(val)
psquare.marker_positions
```
gives us `array([1, 2, 3, 4, 6])` which is not right (as max marker position becomes greater than the the number of values entered)